### PR TITLE
Leave space between sentences in the search string

### DIFF
--- a/lib/rumors/api/client/base.rb
+++ b/lib/rumors/api/client/base.rb
@@ -6,7 +6,7 @@ module Rumors
         SIMILARITY = 0.8
 
         def initialize(text)
-          @text = text.split.join("")
+          @text = text.split.join(" ")
         end
 
         def search


### PR DESCRIPTION
In recent error logs of cofacts URL resolver, I found that there are message body being attached around the URL, and it happens quite frequently.

https://photos.app.goo.gl/FD6YpvhQsqk5TrmKA

Actually I not sure why a `split` is needed here. But least a space is required when joining the split strings, or Cofacts API cannot extract the URL correctly.

